### PR TITLE
use jquery instead of mixing vanilla JS with jQuery

### DIFF
--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -1,24 +1,22 @@
 $(document).ready(function() {
+	var timeLeft = 30;
+	var $elem = $('#timer');
 
+	var timerId = setInterval(countdown, 1000);
 
-var timeLeft = 30;
-var elem = document.getElementById('#timer');
+	$elem.empty();
+	$elem.text(timeLeft);
 
-var timerId = setInterval(countdown, 1000);
+	function countdown() {
+		if (timeLeft == 0) {
+			clearTimeout(timerId);
+			alert('Times up!');
 
-$('#timer').empty();
-$('#timer').append(timeLeft);
-
-function countdown() {
-  if (timeLeft == 0) {
-    clearTimeout(timerId);
-    alert('Times up!');
-
-  } else {
-    elem.innerHTML = timeLeft + ' Time Remaining';
-    timeLeft--;
-  }
-}
+		} else {
+			$elem.text(timeLeft + ' Time Remaining');
+			timeLeft--;
+		}
+	}
 })
 
 

--- a/index.html
+++ b/index.html
@@ -13,8 +13,8 @@
     <div id="wholePage">
         <h1>Trivia Game!</h1>
         <h3 id='Time'>Time Remaining:
-	<span id='timer'></span>
-    </h3>
+          <span id='timer'></span>
+        </h3>
         <p id='Question1'>Which basketball team won the 2016 NBA Championship?</p>
         <div class='Answers1'>
             <div class='row'>


### PR DESCRIPTION
I replaced document.getElementById with $('#id') instead - when you call document.getElementById, you don't use use the "#" symbol, it would look like this:

```
document.getElementById('timer');
```
whereas in jQuery, it's
```
$('#timer');
```

Instead of using innerHTML, use .text() or .html() function of jQuery! Once you're using jQuery, commit to using it - mixing plan vanilla JS and jQuery together (for DOM manipulation) will lead to a lot of confusion :)

Also, I fixed spacing in index.html